### PR TITLE
Update image sizes when preoptimizing images during build

### DIFF
--- a/scripts/optimize-images.ts
+++ b/scripts/optimize-images.ts
@@ -6,7 +6,7 @@ const optimizeImages = async () => {
   await zimg({
     cwd: process.cwd(),
     pattern: `${mediaPath}/*.{jpg,jpeg,png}`,
-    sizes: [160, 320, 480, 640, 960, 1280, 2560, 3840],
+    sizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     quality: 100,
   })
 }


### PR DESCRIPTION
Sizes are from https://nextjs.org/docs/app/api-reference/components/image#devicesizes